### PR TITLE
Fix compilation error

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -42,7 +42,7 @@ outputWith action typ code =
                      code
     _ -> error "Unknown parser type."
 
-fix :: AppFixity ast => ast -> ast
+fix :: AppFixity ast => ast SrcSpanInfo -> ast SrcSpanInfo
 fix = fromMaybe (error "fix") . applyFixities baseFixities
 
 instance Alternative ParseResult where


### PR DESCRIPTION
ghc version: 7.6.3
cabal version: 1.18.0.2

While installing this package, an error occurred:

```
src/Main.hs:45:25:
    Expecting one more argument to `ast'
    In the type signature for `fix': fix :: AppFixity ast => ast -> ast
```
