### PR TITLE
Fix file headers and footer, add autoload cookie for mode

### DIFF
--- a/elisp/shm.el
+++ b/elisp/shm.el
@@ -1,4 +1,4 @@
-;;; structured-haskell-mode --- Structured editing for Haskell
+;;; shm.el --- Structured Haskell Mode
 
 ;; Copyright (c) 2013 Chris Done. All rights reserved.
 ;; Copyright (c) 1998 Heribert Schuetz, Graeme E Moss
@@ -104,6 +104,7 @@
 (defvar shm-lighter " SHM?"
   "The lighter for structured Haskell mode.")
 
+;;;###autoload
 (define-minor-mode structured-haskell-mode
   "Structured editing for Haskell."
   :lighter shm-lighter
@@ -2720,7 +2721,7 @@ deletion. The markers will be garbage collected eventually."
 
 (provide 'shm)
 
-;;; structured-haskell-mode.el ends here
+;;; shm.el ends here
 ;; Local Variables:
 ;; byte-compile-warnings: (not cl-functions)
 ;; End:


### PR DESCRIPTION
For package.el, the ";;; blah.el" lines must match the name of the containing file (which, in turn, must match the name of any package built from the file).

Alternatively, it might ultimately be clearer to rename `shm.el` to `structured-haskell-mode.el`, though that's a bit more work. For the sake of packaging, a further alternative still would be to provide a `structured-haskell-mode-pkg.el` file but to leave the existing files as-is -- this would allow the package to be called `structured-haskell-mode`.

(Re. https://github.com/milkypostman/melpa/pull/1403)
