### PR TITLE
Add shm/modify-type-constraint

### DIFF
--- a/elisp/shm-tests.el
+++ b/elisp/shm-tests.el
@@ -23,6 +23,37 @@
 
 (defvar shm-tests
   (list
+
+   (list :name "add-initial-type-constraint"
+      :start-buffer-content "fn :: a -> b
+"
+      :start-cursor 13
+      :finish-cursor 7
+      :current-node-overlay '(7 12)
+      :end-buffer-content "fn ::  => a -> b
+"
+      :kbd [41 134217848 115 104 109 47 109 111 100 tab return])
+
+(list :name "add-additional-type-constraint-no-parens"
+      :start-buffer-content "fn :: Eq a => a -> a
+"
+      :start-cursor 21
+      :finish-cursor 14
+      :current-node-overlay '(11 15)
+      :end-buffer-content "fn :: (Eq a, ) => a -> a
+"
+      :kbd [41 41 134217848 115 104 109 47 109 111 tab return])
+
+(list :name "add-addtional-type-constraint-parens"
+      :start-buffer-content "fn :: (Ord s, Eq a, Monad m) => StateT s m a
+"
+      :start-cursor 45
+      :finish-cursor 30
+      :current-node-overlay '(27 30)
+      :end-buffer-content "fn :: (Ord s, Eq a, Monad m, ) => StateT s m a
+"
+      :kbd [41 41 134217848 115 104 109 47 109 111 tab return])
+
    (list :name "newline-indent-type-sig-arrows"
          :start-buffer-content "outputWith :: Show a => String -> String -> String -> IO ()
 "

--- a/elisp/shm.el
+++ b/elisp/shm.el
@@ -2672,6 +2672,71 @@ the line."
             (shm-insert-string " qualified")
             (just-one-space 1))))))))
 
+(defun shm/modify-type-constraint ()
+  "Modify a type signatures constraint"
+  (interactive)
+  (let* ((pair (shm-current-node-pair))
+         (current-node (cdr pair)))         
+    (if (shm-type-signature-with-constraint-p pair)
+        (shm-add-additional-type-constraint current-node)
+      (add-initial-type-constraint current-node))))
+
+(defun shm-add-additional-type-constraint (node)
+  (if (shm-constraint-has-parens-p node)
+      (progn
+        (shm-goto-end-of-constraint node)
+        (backward-char 1)
+        (insert ", "))
+    (goto-char (shm-node-start node))
+    (insert "(")
+    (shm-goto-end-of-constraint node)
+    (insert ", )")            
+    (backward-char 1)))
+
+(defun add-initial-type-constraint (node)
+  (goto-char (shm-node-start node))
+  (insert " => ") (backward-char 4))
+
+(defun shm-top-level-type-decl-p (node-pair)
+  (let ((current-node (cdr node-pair)))
+    (if (and (not (shm-has-parent-with-matching-type-p node-pair))
+             (string= "Type SrcSpanInfo" (shm-node-type current-node))) t)))
+
+(defun shm-type-signature-with-constraint-p (pair)
+  (let ((current-node (cdr pair)))
+    (and (shm-top-level-type-decl-p pair)
+         (shm-node-syntax-contains-regex "=>" current-node))))
+
+(defun shm-constraint-has-parens-p (node)
+   (let* ((syntax (shm-concrete-syntax-for-node node))
+          (constraint-syntax (car (split-string syntax "=>"))))
+     (string-match-p ")" constraint-syntax)))
+
+(defun shm-goto-end-of-constraint (node)
+  "Set point to the first white-space character between the end of the type constraint and the '=>'"
+  (goto-char (+ (shm-node-start node)
+                (shm-node-syntax-contains-regex "=>" node)))
+  (re-search-backward "^\\|[^[:space:]]") (goto-char (+ (point) 1)))
+
+(defun shm-node-syntax-contains-regex (regex node)
+  "check the syntax of a node for an occurrence of pattern"
+  (let ((node-concrete-syntax (shm-concrete-syntax-for-node node)))
+    (string-match-p regex node-concrete-syntax)))
+
+(defun shm-concrete-syntax-for-node (node)
+  "Get the concrete syntax of the node"
+  (buffer-substring-no-properties 
+   (shm-node-start (shm-current-node))
+   (shm-node-end (shm-current-node))))
+
+(defun shm-has-parent-with-matching-type-p (node-pair)
+  (let* ((current (cdr node-pair))
+         (parent-pair (shm-node-parent node-pair (shm-node-type current)))
+         (parent (cdr parent-pair)))
+    (if parent
+        (if (string= (shm-node-type current)
+                     (shm-node-type parent)) t))))
+
 (provide 'shm)
 
 ;;; shm.el ends here


### PR DESCRIPTION
Add new type constraints to a selected 'full' type signature node.

This is sort of a work around for not being able to select the relevant portion of a type constraint node. So simply select the whole type signature and invoke the command.  
