### PR TITLE
Don't insert a space after an apostroph

### DIFF
--- a/elisp/shm-insert-del.el
+++ b/elisp/shm-insert-del.el
@@ -481,10 +481,11 @@ here."
     (shm-insert-string open))
    (t
     (shm/reparse)
-    (let ((current (shm-actual-node)))
+    (let ((current (shm-actual-node))
+          (looking-back-regexp "\\(\\(^\\|\\W\\)'\\|[ ,[({\\!]\\)"))
       (cond
        ((shm-find-overlay 'shm-quarantine)
-        (if (not (or (looking-back "[ ,[({\\!]")
+        (if (not (or (looking-back looking-back-regexp)
                      (and (looking-back "\\$")
                           (string= "(" open))
                      (bolp)))
@@ -498,7 +499,7 @@ here."
             (shm-insert-string " "))
           (goto-char point)))
        (t
-        (if (not (or (looking-back "[ ,[({!\\]")
+        (if (not (or (looking-back looking-back-regexp)
                      (bolp)))
             (progn (shm-insert-string " ") 1)
           0)


### PR DESCRIPTION
Apostrophs are used for typelevel stuff like '[] and '(), so inserting a
space is annoying

I couldn't come up with a case where inserting a space there is actually useful, so I guess this is fine.