### PR TITLE
Disable electric indent during testing

### DIFF
--- a/elisp/shm-test.el
+++ b/elisp/shm-test.el
@@ -44,6 +44,8 @@
   (structured-haskell-mode t)
   (when (fboundp 'god-local-mode)
     (god-local-mode -1))
+  (when (fboundp 'electric-indent-mode)
+    (electric-indent-mode -1))
   (erase-buffer)
   (insert "\n")
   (setq shm-test-eob (set-marker (make-marker) (point)))
@@ -123,6 +125,8 @@
   (kill-all-local-variables)
   (when (fboundp 'god-local-mode)
     (god-local-mode -1))
+  (when (fboundp 'electric-indent-mode)
+    (electric-indent-mode -1))
   (let ((customizations (plist-get test :customizations)))
     (when customizations
       (dolist (entry customizations)

--- a/structured-haskell-mode.cabal
+++ b/structured-haskell-mode.cabal
@@ -44,4 +44,4 @@ executable structured-haskell-mode
   build-depends:     base >= 4 && < 5
                    , haskell-src-exts == 1.15.*
                    , text
-                   , descriptive >= 0.7 && < 0.8
+                   , descriptive >= 0.7 && < 0.9


### PR DESCRIPTION
electric-indent-mode causes the tests to fail because C-j obviously behaves differently there. I also bumped descriptive as it seems to work just fine.