### PR TITLE
haskell-src-exts upgraded to 1.16

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -166,8 +166,8 @@ pre x i =
                                (srcSpanStartColumn start)
                                (srcSpanEndLine end)
                                (srcSpanEndColumn end))
-             |Just (IHead (SrcSpanInfo start _) _ _) <- [listToMaybe ds]
-             ,Just (IHead (SrcSpanInfo end _) _ _) <- [listToMaybe (reverse ds)]]
+             |Just (IRule _ _ _ (IHCon (SrcSpanInfo start _) _)) <- [listToMaybe ds]
+             ,Just (IRule _ _ _ (IHCon (SrcSpanInfo end _) _)) <- [listToMaybe (reverse ds)]]
            _ -> []
 
 -- | Generate a span from a HSE SrcSpan.

--- a/structured-haskell-mode.cabal
+++ b/structured-haskell-mode.cabal
@@ -42,6 +42,6 @@ executable structured-haskell-mode
   ghc-options:       -O2 -Wall
   hs-source-dirs:    src
   build-depends:     base >= 4 && < 5
-                   , haskell-src-exts == 1.15.*
+                   , haskell-src-exts == 1.16.*
                    , text
                    , descriptive >= 0.7 && < 0.8


### PR DESCRIPTION
Hello!
I was tried to upgrade the ``haskell-src-exts`` up to 1.16.0.1 (it is a current version on Stackage, nix, LTSHaskell). It typechecks for now, but I could break something (my Haskell skill still isn't good enough to predict all the consequences).