### PR TITLE
Remove redundant shm-auto-insert-lambda definition

### DIFF
--- a/elisp/shm-insert-del.el
+++ b/elisp/shm-insert-del.el
@@ -102,14 +102,6 @@
         )
        (t (shm-insert-string " "))))))
 
-(defun shm-auto-insert-lambda ()
-  "Lambda insertion."
-  (save-excursion
-    (shm/insert-underscore)
-    (forward-char)
-    (insert " -> ")
-    (shm/insert-undefined)))
-
 (defun shm-nothing-following-p ()
   "Is there nothing following me (other than closing delimiters)?"
   (or (eolp)


### PR DESCRIPTION
Definition in shm-insert-del.el is redundant because there's already
one in shm-slot.el which also has better documentation.