### PR TITLE
Accept non-Haskell QuasiQuotes

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -184,7 +184,7 @@ post mode x =
     Just (QuasiQuote (base :: SrcSpanInfo) qname content) ->
       case parseExpWithMode mode content of
         ParseOk ex -> genHSE mode (fmap (redelta qname base) ex)
-        ParseFailed _ e -> error e
+        ParseFailed _ _ -> []
     _ -> []
 
 -- | Apply a delta to the positions in the given span from the base.


### PR DESCRIPTION
Rather than throwing an error (thus making it impossible to use shm in a
function that has a QQ somewhere in it), instead just gracefully fail.

Ideally, the contents of the QuasiQuote would be one context contained
within the overall QQ, but I couldn't figure out how to do that.

Closes #116.