### PR TITLE
relaxing dependency bounds for haskell-src-exts

### DIFF
--- a/structured-haskell-mode.cabal
+++ b/structured-haskell-mode.cabal
@@ -42,7 +42,7 @@ executable structured-haskell-mode
   ghc-options:       -O2 -Wall
   hs-source-dirs:    src
   build-depends:     base >= 4 && < 5
-                   , haskell-src-exts == 1.16.*
+                   , haskell-src-exts >= 1.16
                    , text
                    , descriptive >= 0.7 && < 0.10
                    , applicative-quoters


### PR DESCRIPTION
as mentioned in https://github.com/chrisdone/structured-haskell-mode/issues/121