### PR TITLE
Improve parsing of declarations that contain preprocessor and comments at 0th column

### DIFF
--- a/elisp/shm-ast.el
+++ b/elisp/shm-ast.el
@@ -207,7 +207,8 @@ imagine."
                                (shm-extra-arguments)))
               ((file-error)
                (error "Unable to find structured-haskell-mode executable! See README for help.")))))
-        (read (buffer-string))))))
+        (goto-char (point-min))
+        (read (current-buffer))))))
 
 (defun shm-check-ast (type start end)
   "Check whether the region of TYPE from START to END parses.

--- a/elisp/shm-ast.el
+++ b/elisp/shm-ast.el
@@ -169,6 +169,16 @@ and instate this one."
     (font-lock-fontify-buffer)
     (buffer-substring (+ (point-min) (length "x=")) (point-max))))
 
+(defun shm/call-process-region-ignoring-comments (start end prog-name delete out-buffer display &rest args)
+  (save-match-data
+    (let ((source-code (buffer-substring-no-properties start end)))
+      (with-temp-buffer
+        (insert source-code)
+        (goto-char (point-min))
+        (while (search-forward-regexp "^#.*$" nil t)
+          (replace-match ""))
+        (apply #'call-process-region (point-min) (point-max) prog-name delete out-buffer display args)))))
+
 (defun shm-get-ast (type start end)
   "Get the AST for the given region at START and END. Parses with TYPE.
 
@@ -185,7 +195,7 @@ imagine."
         (let ((temp-buffer (current-buffer)))
           (with-current-buffer buffer
             (condition-case e
-                (apply #'call-process-region
+                (apply #'shm/call-process-region-ignoring-comments
                        (append (list start
                                      end
                                      shm-program-name
@@ -209,7 +219,7 @@ parses."
     (with-temp-buffer
       (let ((temp-buffer (current-buffer)))
         (with-current-buffer buffer
-          (apply #'call-process-region
+          (apply #'shm/call-process-region-ignoring-comments
                  (append (list start
                                end
                                shm-program-name

--- a/elisp/shm-ast.el
+++ b/elisp/shm-ast.el
@@ -358,7 +358,8 @@ expected to work."
                                    (search-backward-regexp "^[^ \n]" nil t 1)
                                    (cond
                                     ((save-excursion (beginning-of-line)
-                                                     (looking-at-p skip-at-start-re))
+                                                     (and (not (bobp))
+                                                          (looking-at-p skip-at-start-re)))
                                      (jump))
                                     (t (unless (or (looking-at-p "^-}$")
                                                    (looking-at-p "^{-$"))


### PR DESCRIPTION
When encountering functions like
```haskell
foo :: Bar
foo = Bar
  { field1 = 1
#ifdef QUUX
  , field2 = 2
#endif
  , field3 = 3
-- , field 4 = 4
  }
```

the structured haskell mode fails to detect bounds of declarations like `foo` and uses incomplete bounds which fail to parse and produce a parse error. These patches attempt to reduce that behavior by teaching shm-decl-points about comments and preprocessor definitions in 0th column. And when sending declaration for to structured-haskell-mode executable all preprocessor lines are replaced by blank lines, since it doesn't digest declarations containing preprocessor parts well (I haven't dug deep into the issue though).