### PR TITLE
Use modern GHC and libraries

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,5 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-2.17
+
+resolver: lts-5.13

--- a/structured-haskell-mode.cabal
+++ b/structured-haskell-mode.cabal
@@ -45,5 +45,4 @@ executable structured-haskell-mode
                    , haskell-src-exts >= 1.16
                    , text
                    , descriptive >= 0.7 && < 0.10
-                   , applicative-quoters
                    , ghc-prim


### PR DESCRIPTION
Uses stack `lts-5.x`, and drops the dependency on `applicative-quoters`. 

This builds and works, but usage itself is buggy. There are bugs unrelated to this still present.