### PR TITLE
Deactivate mark after copying region

### DIFF
--- a/elisp/shm-yank-kill.el
+++ b/elisp/shm-yank-kill.el
@@ -36,7 +36,8 @@
   "Copy the region, and save it in the clipboard."
   (interactive "r")
   (save-excursion
-    (shm-kill-region 'clipboard-kill-ring-save beg end t)))
+    (shm-kill-region 'clipboard-kill-ring-save beg end t))
+  (setq deactivate-mark t))
 
 (defun shm/kill-line ()
   "Kill everything possible to kill after point before the end of


### PR DESCRIPTION
I keep getting confused by the fact that contrary to the beavior of `'C-w` (`kill-ring-save`) everwhere else the region here stays active. This PR changes it so that it gets deactivated afterwards.