### PR TITLE
Constrain haskell-src-exts to versions <1.20

### DIFF
--- a/structured-haskell-mode.cabal
+++ b/structured-haskell-mode.cabal
@@ -44,7 +44,7 @@ executable structured-haskell-mode
   ghc-options:       -O2 -Wall
   hs-source-dirs:    src
   build-depends:     base >= 4 && < 5
-                   , haskell-src-exts >= 1.18
+                   , haskell-src-exts >= 1.18 && < 1.20
                    , text
                    , descriptive >= 0.7 && < 0.10
                    , ghc-prim


### PR DESCRIPTION
The build with `haskell-src-exts-1.20.2` fails:

~~~
src/Main.hs:165:18: error:
    • The constructor ‘Deriving’ should have 3 arguments, but has been given 2
    • In the pattern: Deriving _ ds@(_ : _)
      In the pattern: Just (Deriving _ ds@(_ : _))
      In a case alternative:
          Just (Deriving _ ds@(_ : _))
            -> [spanHSE
                  (show "InstHeads")
                  "InstHeads"
                  (SrcSpan
                     (srcSpanFilename start)
                     (srcSpanStartLine start)
                     (srcSpanStartColumn start)
                     (srcSpanEndLine end)
                     (srcSpanEndColumn end)) |
                  Just (IRule _ _ _ (IHCon (SrcSpanInfo start _) _)) <- [listToMaybe
                                                                           ds],
                  Just (IRule _ _ _ (IHCon (SrcSpanInfo end _) _)) <- [listToMaybe
                                                                         (reverse ds)]]
    |
165 |            Just (Deriving _ ds@(_:_)) ->
    |                  ^^^^^^^^^^^^^^^^^^^
~~~